### PR TITLE
Updates to Introduction

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -1,12 +1,12 @@
 # Introduction
 
-*This is still a work in progress and only presented here for the purposes of receiving feedback. This message will be removed when the guidelines have been officially published.*
+*This is still a work in progress and only presented here for the purposes of receiving feedback. This message will be removed when the Primer Guide has been officially published.*
 
-To paraphrase the [MARCO-BOLO data management plan](https://doi.org/10.5281/zenodo.8208410), the main challenge with biological data is that it comes in many flavors. For example, it may include evidence of past or present organisms based on physical samples, chemicals, organic molecules, sound, or images. By using standards to organize and share data efficiently, biologists can turn this diversity of data types into a strength rather than a challenge of dealing with biological data.
+To paraphrase the [MARCO-BOLO data management plan](https://doi.org/10.5281/zenodo.8208410), the main challenge with biological data is that it comes in many flavors. For example, it may include evidence of past or present organisms based on physical samples, chemicals, organic molecules, sound, or images. By using standards to organize and share data efficiently, biologists can turn this diversity of data types into a strength rather than a challenge when dealing with biological data.
 
-### This Guide
+### This Primer Guide
 
-The first product from this cluster, the [Biological Data Standards Primer](https://doi.org/10.6084/m9.figshare.16806712.v2) is an easy to digest resource for new biological data managers. However, it is essentially a list of names and links. We created this guide to build on the Primer by providing additional context and details to the items listed in the Primer. The guide is intended to be a bridge between a deep dive into standards documentation and the lists of links available in the Primer. 
+The first product from this cluster, the [Biological Data Standards Primer](https://doi.org/10.6084/m9.figshare.16806712.v2), is an easy to digest resource for new biological data managers. However, it is essentially a list of names and links. We created this Primer Guide with the intention of providing additional context, bridging the gap between technical standards documentation and the lists of links available in the Primer. 
 
 <iframe src="https://widgets.figshare.com/articles/16806712/embed?show_title=1" width="600" height="400" allowfullscreen frameborder="0">
 
@@ -14,12 +14,7 @@ The first product from this cluster, the [Biological Data Standards Primer](http
 
 #### Audience
 
-The target audience for these guides is anyone interested in working with biological data, from data collection, to data sharing, and data management. We hope this Primer Guide will provide useful context for using biological standards.
-
-##### Translations
-Currently we only have the capacity to offer it in English. However, users can get a rough translation using Google Translate. 
-Just drop the url in this service: <https://translate.google.com/?sl=en&tl=es&op=websites>
-
+The target audience for this Primer Guide is anyone interested in working with biological data, from data collection, to data sharing, and data management. We hope this Primer Guide will provide useful context for using biological standards.
 
 ::: callout-note
 ## Key Values
@@ -34,9 +29,9 @@ In designing this resource, we focused on a few key values.
 :::
 
 
-### Background on the Cluster and the Primer
+### Background on the Cluster
 
-The [ESIP Biological Data Standards Cluster](https://wiki.esipfed.org/Biological_Data_Standards_Cluster) formed in 2020 to maximize data relevance and utility for understanding changes in biodiversity over time. The cluster’s focus has expanded to include more aspects of biology beyond biodiversity, acknowledging that biological data may be useful for many facets of earth science. To accomplish this, the cluster encourages awareness and shared understanding of biological data standards by facilitating community building and information sharing via guidance, documentation, and training for the US biological data community. The first product from this cluster, the [Biological Data Standards Primer](https://doi.org/10.6084/m9.figshare.16806712.v2), is an easy to digest resource for new biological data managers.
+The [ESIP Biological Data Standards Cluster](https://wiki.esipfed.org/Biological_Data_Standards_Cluster) formed in 2020 to maximize data relevance and utility for understanding changes in biodiversity over time. The cluster’s focus has expanded to include more aspects of biology beyond biodiversity, acknowledging that biological data may be useful for many facets of earth science. To accomplish this, the cluster encourages awareness and shared understanding of biological data standards by facilitating community building and information sharing via guidance, documentation, and training for the US biological data community. 
 
 ### How to contribute to this Primer Guide
 


### PR DESCRIPTION
- Consistency: changed guide/guidelines to Primer Guide
- Removed the translation section: personally I don't find it very useful, plus we also indicate that it's mainly for the "US biological data community"
- Changed a sentence in the "This Primer Guide" section to have it flow a bit better
- Removed a second reference to the Primer in the "Background on the Cluster" section
- Changed Background on the Cluster and Primer to remove the "and Primer".